### PR TITLE
Make codeblock fonts monospace

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -4,6 +4,10 @@
   font-family: "Outfit";
 }
 
+code * {
+  font-family: monospace !important;
+}
+
 /* misery */
 :root {
   --vp-c-brand-1: ##6284f2;


### PR DESCRIPTION
With:
<img width="200" alt="Non-monospace" src="https://github.com/user-attachments/assets/1282158e-eeae-45cf-9381-b44013f7825c" />
Without:
<img width="200" alt="Monospace" src="https://github.com/user-attachments/assets/0fe74a01-20b6-41d0-bc7d-62ce55179b75" />
